### PR TITLE
range_union_internal is exported in pg14

### DIFF
--- a/util.c
+++ b/util.c
@@ -1,3 +1,5 @@
+#if PG_VERSION_NUM < 14000
+
 /*
  * Lots of stuff copied from backend/utils/adt/rangetypes.c
  */
@@ -55,4 +57,4 @@ range_union_internal(TypeCacheEntry *typcache, RangeType *r1, RangeType *r2,
 
   return make_range(typcache, result_lower, result_upper, false);
 }
-
+#endif


### PR DESCRIPTION
This change allows compiling the extension with Postgres 14 and below.